### PR TITLE
Added ability to save shaders with Mongoose/MongoDB

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 
-var express = require("express");
+var express  = require("express"),
+    mongoose = require("mongoose")
 
+require("./datamodel").configureSchema(mongoose.Schema, mongoose);
+var Shader = mongoose.model("Shader");
 
 var app = express.createServer(express.logger());
+app.db = mongoose.connect(process.env.MONGO_URI);
 app.configure(function () {
   app.use(express.static(__dirname + "/public"));
   app.use(express.bodyParser());
@@ -23,6 +27,93 @@ app.configure("production", function () {
 
 app.get("/", function (req, res) {
   res.render("index", { env: app.settings.env, layout: false });
+});
+
+
+app.get("/get", function(req, res){
+  Shader.find()
+    .skip(req.query["skip"])
+    .limit(req.query["limit"])
+    .sort("date", -1)
+    .exec(function (err, shaders) {
+      if (err) {
+        res.send("Error fetching shaders.");
+      } else {
+        res.json({
+          status : "OK",
+          shaders : shaders
+        });
+      }
+    });
+});
+
+
+app.get("/count", function(req, res){
+  Shader.find().count().exec(function (err, count) {
+    if (err) {
+      res.send("Error counting shaders.");
+    } else {
+      res.json({
+        status : "OK",
+        count : count
+      });
+    }
+  });
+});
+
+
+app.get("/short/:short_id",function(req, res){
+  Shader.findOne({ short_id : req.params.short_id }, function(err, shader){
+    if (err) {
+      res.send("Error finding shader with short_id: " + req.params.short_id);
+    } else {
+      res.json({
+        status : "OK",
+        shader : shader
+      });
+    }
+  });
+});
+
+
+app.post("/save", function(req, res){
+
+  console.log("Receiving new shader to store...");
+  console.log(req.body);
+
+  var generateID = function(length) {
+    var id = "";
+    var chars = "qwrtypsdfghjklzxcvbnm0123456789";
+    while(id.length < length) {
+      var pos = Math.floor(Math.random() * chars.length - 1);
+      id += chars.substring(pos, pos + 1);
+    }
+    return id;
+  }
+
+  var saveShader = function(iteration, callback) {
+    var newShader = new Shader({
+      short_id : generateID(iteration),
+      code_lzma : req.body.code_lzma
+    });
+    newShader.save(function (err) {
+      if (err !== null && err.code === 11000) {
+        console.log("Duplicate short_id; Generating another...");
+        saveShader(iteration += 1, callback);
+      }
+      else {
+        callback(this.emitted.complete[0]);
+      }
+    });
+  };
+
+  saveShader(1, function(savedShader) {
+    console.log("Saving Success!", savedShader);
+    res.json({
+      status : "OK",
+      shader : savedShader
+    });
+  });
 });
 
 

--- a/app.js
+++ b/app.js
@@ -62,7 +62,7 @@ app.get("/count", function(req, res){
 });
 
 
-app.get("/short/:short_id",function(req, res){
+app.get("/s/:short_id",function(req, res){
   Shader.findOne({ short_id : req.params.short_id }, function(err, shader){
     if (err) {
       res.send("Error finding shader with short_id: " + req.params.short_id);
@@ -94,7 +94,9 @@ app.post("/save", function(req, res){
   var saveShader = function(iteration, callback) {
     var newShader = new Shader({
       short_id : generateID(iteration),
-      code_lzma : req.body.code_lzma
+      r : req.body.r,
+      d : req.body.d,
+      z : req.body.z
     });
     newShader.save(function (err) {
       if (err !== null && err.code === 11000) {

--- a/datamodel.js
+++ b/datamodel.js
@@ -1,7 +1,9 @@
 module.exports.configureSchema = function(Schema, mongoose) {
   mongoose.model('Shader', new Schema({
     short_id : { type: String, unique: true },
-    code_lzma : String,
     date : { type: Date, default: Date.now },
+    z : String,
+    r : Array,
+    d : String
   }));
 };

--- a/datamodel.js
+++ b/datamodel.js
@@ -1,0 +1,7 @@
+module.exports.configureSchema = function(Schema, mongoose) {
+  mongoose.model('Shader', new Schema({
+    short_id : { type: String, unique: true },
+    code_lzma : String,
+    date : { type: Date, default: Date.now },
+  }));
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "2.5.x",
+    "mongoose": "2.5.x",
     "ejs": "0.8.x",
     "requirejs": "2.x.x"
   },

--- a/public/src/models/Toy.js
+++ b/public/src/models/Toy.js
@@ -43,6 +43,11 @@ define(function (require) {
           hides_when_closed: true
         },
         {
+          name: "link",
+          title: "Link",
+          hides_when_closed: true
+        },
+        {
           name: "help",
           title: "?",
           hides_when_closed: true
@@ -85,6 +90,7 @@ define(function (require) {
         });
 
       this.editor.buttons.get("save").on("click", this.saveParams, this);
+      this.editor.buttons.get("link").on("click", this.saveShaderToDB, this);
       this.editor.buttons.get("help").on("click", function () {
         self.help.set("open", true);
       });
@@ -232,6 +238,21 @@ define(function (require) {
       this.editor.buttons.get("save").set({
         title: saved ? "Saved" : "Save",
         enabled: !saved
+      });
+    },
+
+    saveShaderToDB: function () {
+      var self = this;
+      Params.lzmaCompress(this.editor.get("src_fragment"), 1, function (res) {
+        var params = {};
+        if(self.has("rotation"))
+          params.r = self.get("rotation");
+        if(self.has("distance"))
+          params.d = self.get("distance");
+        params.z = res;
+        $.post('/save', params, function(response){
+          console.log(response);
+        });
       });
     },
 


### PR DESCRIPTION
Added the following endpoints:

/get
@param: integer skip
@param: integer limit
@desc: gets shaders, sorted by date

/count
@desc: gets total count of shaders in db

/s/:short_id
@param: string short_id (shader short id)
@desc: get a shader by its short id

/save
@param: array r (rotation)
@param: float d (distance)
@param: string z (shader lzma)
@desc: saves shader to DB

Saving is implemented with a (temporary) "link" button in the UI. Perhaps this could be integrated into the existing "save" button.

When "link" is clicked, the current shader+params posts to the db. View the status of the post in the console.

Shaders can be retrieved via /get or /s/:short_id
