### PR TITLE
Added ability to save shaders with MYSQL

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-var express = require("express");
+var express = require("express"),
+    mysql   = require('mysql');
 
-
+var db = mysql.createConnection(process.env.MYSQL_URI);
 var app = express.createServer(express.logger());
 app.configure(function () {
   app.use(express.static(__dirname + "/public"));
@@ -23,6 +24,103 @@ app.configure("production", function () {
 
 app.get("/", function (req, res) {
   res.render("index", { env: app.settings.env, layout: false });
+});
+
+app.get("/get", function (req, res) {
+  var offset = req.query["offset"] ? parseInt(req.query["offset"]) : 0;
+  var limit  = req.query["limit"] ? parseInt(req.query["limit"])  : 25;
+  var slice = offset + ", " + limit;
+  db.query("SELECT * FROM shaders ORDER BY date LIMIT " + slice,
+    function(err, rows) {
+      if (rows) {
+        var result = [];
+        for(var i = 0; i < rows.length; i++) {
+          result[i] = rows[i];
+          result[i].r = rows[i].r.split(",");
+        }
+        res.json({
+          status : "OK",
+          shader : result
+        });
+      }
+      else {
+        res.json({
+          status : "NOT OK"
+        });
+      }
+    }
+  );
+});
+
+app.get("/get/:short_id",function(req, res){
+  db.query("SELECT * FROM shaders WHERE short_id = ?", req.params.short_id,
+    function(err, results) {
+      if (err) {
+        res.send("Error finding shader with short_id: " + req.params.short_id);
+      } else {
+        var result = results[0];
+        if (result) {
+          result.r = result.r.split(",");
+          res.json({
+            status : "OK",
+            shader : result
+          });
+        } else {
+          res.json({
+            status : "NOT FOUND"
+          });
+        }
+      }
+  });
+});
+
+
+app.get("/count", function(req, res){
+  db.query("SELECT COUNT(*) as count FROM shaders",
+    function(err, result) {
+      res.json({
+        status : "OK",
+        count : result[0].count
+      });
+  });
+});
+
+
+app.post("/save", function(req, res) {
+
+  var generateID = function(length) {
+    var id = "";
+    var chars = "qwrtypsdfghjklzxcvbnm0123456789";
+    while(id.length < length) {
+      var pos = Math.floor(Math.random() * chars.length - 1);
+      id += chars.substring(pos, pos + 1);
+    }
+    return id;
+  }
+
+  var saveShader = function(iteration, callback) {
+    var short_id = generateID(iteration);
+    db.query('INSERT INTO shaders SET ?',
+        { short_id: short_id,
+          r: req.body.r.join(","),
+          d: req.body.d,
+          z: req.body.z },
+      function(err, result) {
+        if (err && err.code === "ER_DUP_ENTRY") {
+          console.log("Duplicate id; Generating another...");
+          saveShader(iteration += 1, callback);
+        }
+        else {
+          callback(short_id);
+        }
+    });
+  };
+
+  saveShader(1, function(result, short_id) {
+    res.json({
+      short_id : short_id
+    });
+  });
 });
 
 

--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@ app.get("/", function (req, res) {
   res.render("index", { env: app.settings.env, layout: false });
 });
 
+
 app.get("/get", function (req, res) {
   var offset = req.query["offset"] ? parseInt(req.query["offset"]) : 0;
   var limit  = req.query["limit"] ? parseInt(req.query["limit"])  : 25;
@@ -36,6 +37,7 @@ app.get("/get", function (req, res) {
         var result = [];
         for(var i = 0; i < rows.length; i++) {
           result[i] = rows[i];
+          // convert .r to array by splitting on commas
           result[i].r = rows[i].r.split(",");
         }
         res.json({
@@ -52,6 +54,7 @@ app.get("/get", function (req, res) {
   );
 });
 
+
 app.get("/get/:short_id",function(req, res){
   db.query("SELECT * FROM shaders WHERE short_id = ?", req.params.short_id,
     function(err, results) {
@@ -60,6 +63,7 @@ app.get("/get/:short_id",function(req, res){
       } else {
         var result = results[0];
         if (result) {
+          // convert .r to array by splitting on commas
           result.r = result.r.split(",");
           res.json({
             status : "OK",
@@ -102,6 +106,7 @@ app.post("/save", function(req, res) {
     var short_id = generateID(iteration);
     db.query('INSERT INTO shaders SET ?',
         { short_id: short_id,
+          // convert .r to string for DB storage by joining with commas
           r: req.body.r.join(","),
           d: req.body.d,
           z: req.body.z },
@@ -111,13 +116,14 @@ app.post("/save", function(req, res) {
           saveShader(iteration += 1, callback);
         }
         else {
-          callback(short_id);
+          callback(result, short_id);
         }
     });
   };
 
   saveShader(1, function(result, short_id) {
     res.json({
+      insert_id : result.insertId,
       short_id : short_id
     });
   });

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "express": "2.5.x",
+    "mysql": "2.0.x",
     "ejs": "0.8.x",
     "requirejs": "2.x.x"
   },

--- a/public/src/models/Toy.js
+++ b/public/src/models/Toy.js
@@ -43,6 +43,11 @@ define(function (require) {
           hides_when_closed: true
         },
         {
+          name: "saveToDB",
+          title: "SaveToDB",
+          hides_when_closed: true
+        },
+        {
           name: "help",
           title: "?",
           hides_when_closed: true
@@ -86,6 +91,7 @@ define(function (require) {
         });
 
       this.editor.buttons.get("save").on("click", this.editor.save, this.editor);
+      this.editor.buttons.get("saveToDB").on("click", this.saveShaderToDB, this);
       this.editor.buttons.get("help").on("click", function () {
         self.help.set("open", true);
       });
@@ -232,6 +238,21 @@ define(function (require) {
       this.editor.buttons.get("save").set({
         title: saved ? "Saved" : "Save",
         enabled: !saved
+      });
+    },
+
+    saveShaderToDB: function () {
+      var self = this;
+      Params.lzmaCompress(this.editor.get("src_fragment"), 1, function (res) {
+        var params = {};
+        if(self.has("rotation"))
+          params.r = self.get("rotation");
+        if(self.has("distance"))
+          params.d = self.get("distance");
+        params.z = res;
+        $.post('/save', params, function(response){
+         console.log(response);
+        });
       });
     },
 

--- a/shaders.sql
+++ b/shaders.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `shaders` (
+  `id`          int(11)         NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `short_id`    varchar(20)     NOT NULL,
+  `date`        timestamp       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `z`           text,
+  `r`           varchar(255),
+  `d`           float,
+  UNIQUE KEY `short_id` (`short_id`)
+) DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Added the following endpoints:

/get/
gets shaders, sorted by date with limit and offset url params
example: /get/?limit=10&offset=4

/get/:short_id
get shader by short_id
example: /get/4f

/count
get total count of shaders in db

/save
saves shader to DB
@Param: string z shader lzma (required)
@Param: array r rotation (optional)
@Param: float d distance (optional)

When "SaveToDB" is clicked, the current shader+params are posted to the db. View the status of the post in the console.

example MYSQL_URI environment variable (with debug set to true)
MYSQL_URI=mysql://user:pass@hostname/database?debug=true
